### PR TITLE
fix: in-odered polygon

### DIFF
--- a/pyzbar/pyzbar.py
+++ b/pyzbar/pyzbar.py
@@ -106,11 +106,21 @@ def _decode_symbols(symbols):
             for index in _RANGEFN(zbar_symbol_get_loc_size(symbol))
         )
 
+        # since 'polygon' is very misleading if one wants to detect the QR/bar
+        # code position in order no matter how they appear in the scene
+        polygon_upright = list(map(Point._make,(
+            (
+                zbar_symbol_get_loc_x(symbol, index),
+                zbar_symbol_get_loc_y(symbol, index)
+            )
+            for index in _RANGEFN(zbar_symbol_get_loc_size(symbol))
+        )))
+
         yield Decoded(
             data=data,
             type=symbol_type,
             rect=bounding_box(polygon),
-            polygon=polygon
+            polygon=polygon_upright
         )
 
 


### PR DESCRIPTION
This fix will allow obtaining in-ordered polygon vertices for bar/QR code irrespective of the angular placement of the bar/QR code in the scene. This will certainly help for those who are trying to determine the in-order corners of the QR/bar code in the scene i.e. anti-clockwise from the top-left for an upright position.