### PR TITLE
Included x & y density configs in decode()

### DIFF
--- a/pyzbar/pyzbar.py
+++ b/pyzbar/pyzbar.py
@@ -167,13 +167,21 @@ def _pixel_data(image):
     return pixels, width, height
 
 
-def decode(image, symbols=None):
+def decode(image, symbols=None, x_density=None, y_density=None):
     """Decodes datamatrix barcodes in `image`.
 
     Args:
         image: `numpy.ndarray`, `PIL.Image` or tuple (pixels, width, height)
         symbols: iter(ZBarSymbol) the symbol types to decode; if `None`, uses
             `zbar`'s default behaviour, which is to decode all symbol types.
+       
+        x_density: int, controls the number of pixel rows (columns) that are 
+            skipped between successive horizontal (vertical) scan passes.
+            A value of 0 completely disables scanning in this direction.
+        
+        y_density: int, controls the number of pixel rows (columns) that are 
+            skipped between successive horizontal (vertical) scan passes.
+            A value of 0 completely disables scanning in this direction.
 
     Returns:
         :obj:`list` of :obj:`Decoded`: The values decoded from barcodes.
@@ -195,7 +203,21 @@ def decode(image, symbols=None):
             # them.
             for symbol in symbols:
                 zbar_image_scanner_set_config(
-                    scanner, symbol, ZBarConfig.CFG_ENABLE, 1
+                    scanner, symbol, ZBarConfig.CFG_ENABLE, 0
+                )
+        # attempt to disable scan density for x axis
+        # http://zbar.sourceforge.net/iphone/sdkdoc/optimizing.html#limit-the-scan-density
+        # note, the 2nd param seems specific to symbology. Just setting it to 0
+        if x_density is not None:
+            zbar_image_scanner_set_config(
+                    scanner, 0, ZBarConfig.CFG_X_DENSITY, x_density
+                )
+        # attempt to disable scan density for y axis
+        # http://zbar.sourceforge.net/iphone/sdkdoc/optimizing.html#limit-the-scan-density
+        # note, the 2nd param seems specific to symbology. Just setting it to 0
+        if y_density is not None:
+            zbar_image_scanner_set_config(
+                    scanner, 0, ZBarConfig.CFG_Y_DENSITY, y_density
                 )
         with _image() as img:
             zbar_image_set_format(img, _FOURCC['L800'])


### PR DESCRIPTION
This pull request adds 2 parameters to `decode()`:  x_density, and y_density both of which (should) map to the zbar [scan density parameters](http://zbar.sourceforge.net/iphone/sdkdoc/optimizing.html#limit-the-scan-density). This modification was helpful in another project and thought it may be useful to offer the pull request in light of: #30. 

**Important note:** Please see my comments in `decode()` concerning my use of 0 in 2nd parameter when calling the `zbar_image_scanner_set_config()`. I must admit I do not understand that parameter's use beyond symbology.

Hope it helps!