### PR TITLE
Add zbar installation in conda.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,13 @@ Linux:
 
    sudo apt-get install libzbar0
 
+Using conda, the ``zbar`` binaries are available for Linux systems through the conda-forge channel:
+
+::
+
+   conda install --channel conda-forge zbar
+
+
 Install this Python wrapper; use the second form to install dependencies of the
 command-line scripts:
 


### PR DESCRIPTION
It is possible to install zbar binaries in conda environments thanks to conda-forge channel. We are using it to deploy an app within containerized environments using conda, removing the necessity of APT manager.  