### PR TITLE
Add support for imagio subclassed numpy array.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Read one-dimensional barcodes and QR codes from Python 2 and 3 using the
 `zbar <http://zbar.sourceforge.net/>`__ library.
 
 -  Pure python
--  Works with PIL / Pillow images, OpenCV / numpy ``ndarray``\ s, and raw bytes
+-  Works with PIL / Pillow images, OpenCV / numpy ``ndarray``\ s / imageio arrays, and raw bytes
 -  Decodes locations of barcodes
 -  No dependencies, other than the zbar library itself
 -  Tested on Python 2.7, and Python 3.4 to 3.7

--- a/pyzbar/pyzbar.py
+++ b/pyzbar/pyzbar.py
@@ -124,12 +124,13 @@ def _pixel_data(image):
     """
     # Test for PIL.Image and numpy.ndarray without requiring that cv2 or PIL
     # are installed.
-    if 'PIL.' in str(type(image)):
+    image_type = str(type(image))
+    if 'PIL.' in image_type:
         if 'L' != image.mode:
             image = image.convert('L')
         pixels = image.tobytes()
         width, height = image.size
-    elif 'numpy.ndarray' in str(type(image)):
+    elif 'numpy.ndarray' in image_type or 'imageio.core.util.Array' in image_type:
         if 3 == len(image.shape):
             # Take just the first channel
             image = image[:, :, 0]

--- a/pyzbar/tests/test_pyzbar.py
+++ b/pyzbar/tests/test_pyzbar.py
@@ -18,6 +18,11 @@ try:
 except ImportError:
     cv2 = None
 
+try:
+    import imageio
+except ImportError:
+    iamgeio = None
+
 from pyzbar.pyzbar import (
     decode, Decoded, Rect, ZBarSymbol, EXTERNAL_DEPENDENCIES
 )
@@ -123,6 +128,12 @@ class TestDecode(unittest.TestCase):
     def test_decode_numpy(self):
         "Read image using Pillow and convert to numpy.ndarray"
         res = decode(np.asarray(self.code128))
+        self.assertEqual(self.EXPECTED_CODE128, res)
+
+    @unittest.skipIf(imageio is None, 'imageio not installed')
+    def test_decode_imageio(self):
+        "Read image using imageio"
+        res = decode(imageio.imread(str(TESTDATA.joinpath('code128.png'))))
         self.assertEqual(self.EXPECTED_CODE128, res)
 
     @unittest.skipIf(cv2 is None, 'OpenCV not installed')


### PR DESCRIPTION
Added support for [imageio](https://github.com/imageio/imageio) arrays, which are a subclass of numpy arrays. As they are a subclass the current type checker wasn't handling them properly. Changes:

- Added README info.
- Added type _dependecyless_ check.
- Added test to test imageio. 