### PR TITLE
Correctly handle cases where detected data contains null-bytes

### DIFF
--- a/pyzbar/pyzbar.py
+++ b/pyzbar/pyzbar.py
@@ -9,7 +9,7 @@ from .wrapper import (
     zbar_image_scanner_create, zbar_image_scanner_destroy,
     zbar_image_create, zbar_image_destroy, zbar_image_set_format,
     zbar_image_set_size, zbar_image_set_data, zbar_scan_image,
-    zbar_image_first_symbol, zbar_symbol_get_data,
+    zbar_image_first_symbol, zbar_symbol_get_data_length, zbar_symbol_get_data,
     zbar_symbol_get_loc_size, zbar_symbol_get_loc_x, zbar_symbol_get_loc_y,
     zbar_symbol_next, ZBarConfig, ZBarSymbol, EXTERNAL_DEPENDENCIES
 )
@@ -97,7 +97,10 @@ def _decode_symbols(symbols):
         Decoded: decoded symbol
     """
     for symbol in symbols:
-        data = string_at(zbar_symbol_get_data(symbol))
+        data = string_at(
+            zbar_symbol_get_data(symbol),
+            zbar_symbol_get_data_length(symbol)
+        )
         # The 'type' int in a value in the ZBarSymbol enumeration
         symbol_type = ZBarSymbol(symbol.contents.type).name
         polygon = convex_hull(

--- a/pyzbar/wrapper.py
+++ b/pyzbar/wrapper.py
@@ -15,8 +15,9 @@ __all__ = [
     'zbar_image_scanner_create', 'zbar_image_scanner_destroy',
     'zbar_image_scanner_set_config', 'zbar_image_set_data',
     'zbar_image_set_format', 'zbar_image_set_size', 'zbar_scan_image',
-    'zbar_symbol_get_data', 'zbar_symbol_get_loc_size',
-    'zbar_symbol_get_loc_x', 'zbar_symbol_get_loc_y', 'zbar_symbol_next'
+    'zbar_symbol_get_data_length', 'zbar_symbol_get_data',
+    'zbar_symbol_get_loc_size', 'zbar_symbol_get_loc_x',
+    'zbar_symbol_get_loc_y', 'zbar_symbol_next'
 ]
 
 # Globals populated in load_libzbar
@@ -234,7 +235,7 @@ zbar_symbol_get_data_length = zbar_function(
 
 zbar_symbol_get_data = zbar_function(
     'zbar_symbol_get_data',
-    c_char_p,
+    c_ubyte_p,
     POINTER(zbar_symbol)
 )
 


### PR DESCRIPTION
zbar's zbar_symbol_get_data() API function can return data that contains null-bytes. this patch adds support for such cases.