### PR TITLE
Support decoding of binary QR codes

### DIFF
--- a/pyzbar/pyzbar.py
+++ b/pyzbar/pyzbar.py
@@ -167,13 +167,21 @@ def _pixel_data(image):
     return pixels, width, height
 
 
-def decode(image, symbols=None):
+def decode(image, symbols=None, x_density=None, y_density=None):
     """Decodes datamatrix barcodes in `image`.
 
     Args:
         image: `numpy.ndarray`, `PIL.Image` or tuple (pixels, width, height)
         symbols: iter(ZBarSymbol) the symbol types to decode; if `None`, uses
             `zbar`'s default behaviour, which is to decode all symbol types.
+       
+        x_density: int, controls the number of pixel rows (columns) that are 
+            skipped between successive horizontal (vertical) scan passes.
+            A value of 0 completely disables scanning in this direction.
+        
+        y_density: int, controls the number of pixel rows (columns) that are 
+            skipped between successive horizontal (vertical) scan passes.
+            A value of 0 completely disables scanning in this direction.
 
     Returns:
         :obj:`list` of :obj:`Decoded`: The values decoded from barcodes.
@@ -195,7 +203,21 @@ def decode(image, symbols=None):
             # them.
             for symbol in symbols:
                 zbar_image_scanner_set_config(
-                    scanner, symbol, ZBarConfig.CFG_ENABLE, 1
+                    scanner, symbol, ZBarConfig.CFG_ENABLE, 0
+                )
+        # attempt to disable scan density for x axis
+        # http://zbar.sourceforge.net/iphone/sdkdoc/optimizing.html#limit-the-scan-density
+        # note, the 2nd param seems specific to symbology. Just setting it to 0
+        if x_density is not None:
+            zbar_image_scanner_set_config(
+                    scanner, 0, ZBarConfig.CFG_X_DENSITY, x_density
+                )
+        # attempt to disable scan density for y axis
+        # http://zbar.sourceforge.net/iphone/sdkdoc/optimizing.html#limit-the-scan-density
+        # note, the 2nd param seems specific to symbology. Just setting it to 0
+        if y_density is not None:
+            zbar_image_scanner_set_config(
+                    scanner, 0, ZBarConfig.CFG_Y_DENSITY, y_density
                 )
         with _image() as img:
             zbar_image_set_format(img, _FOURCC['L800'])

--- a/pyzbar/pyzbar.py
+++ b/pyzbar/pyzbar.py
@@ -167,13 +167,14 @@ def _pixel_data(image):
     return pixels, width, height
 
 
-def decode(image, symbols=None):
+def decode(image, symbols=None, binary=False):
     """Decodes datamatrix barcodes in `image`.
 
     Args:
         image: `numpy.ndarray`, `PIL.Image` or tuple (pixels, width, height)
         symbols: iter(ZBarSymbol) the symbol types to decode; if `None`, uses
             `zbar`'s default behaviour, which is to decode all symbol types.
+        binary: bool If true, do not convert binary data to text
 
     Returns:
         :obj:`list` of :obj:`Decoded`: The values decoded from barcodes.
@@ -197,6 +198,10 @@ def decode(image, symbols=None):
                 zbar_image_scanner_set_config(
                     scanner, symbol, ZBarConfig.CFG_ENABLE, 1
                 )
+
+        if binary:
+            zbar_image_scanner_set_config(scanner, 0, ZBarConfig.CFG_BINARY, 1)
+
         with _image() as img:
             zbar_image_set_format(img, _FOURCC['L800'])
             zbar_image_set_size(img, width, height)

--- a/pyzbar/wrapper.py
+++ b/pyzbar/wrapper.py
@@ -63,21 +63,23 @@ class ZBarSymbol(IntEnum):
 
 @unique
 class ZBarConfig(IntEnum):
-    CFG_ENABLE = 0          # /**< enable symbology/feature */
-    CFG_ADD_CHECK = 1       # /**< enable check digit when optional */
-    CFG_EMIT_CHECK = 2      # /**< return check digit when present */
-    CFG_ASCII = 3           # /**< enable full ASCII character set */
-    CFG_NUM = 4             # /**< number of boolean decoder configs */
+    CFG_ENABLE = 0            # /**< enable symbology/feature */
+    CFG_ADD_CHECK = 1         # /**< enable check digit when optional */
+    CFG_EMIT_CHECK = 2        # /**< return check digit when present */
+    CFG_ASCII = 3             # /**< enable full ASCII character set */
+    CFG_BINARY = 4,           # /**< don't convert binary data to text */
+    CFG_NUM = 5               # /**< number of boolean decoder configs */
 
-    CFG_MIN_LEN = 0x20      # /**< minimum data length for valid decode */
-    CFG_MAX_LEN = 0x21      # /**< maximum data length for valid decode */
+    CFG_MIN_LEN = 0x20        # /**< minimum data length for valid decode */
+    CFG_MAX_LEN = 0x21        # /**< maximum data length for valid decode */
 
-    CFG_UNCERTAINTY = 0x40  # /**< required video consistency frames */
+    CFG_UNCERTAINTY = 0x40    # /**< required video consistency frames */
 
-    CFG_POSITION = 0x80     # /**< enable scanner to collect position data */
+    CFG_POSITION = 0x80       # /**< enable scanner to collect position data */
+    CFG_TEST_INVERTED = 0x81  # /**< if fails to decode, test inverted * /
 
-    CFG_X_DENSITY = 0x100   # /**< image scanner vertical scan density */
-    CFG_Y_DENSITY = 0x101   # /**< image scanner horizontal scan density */
+    CFG_X_DENSITY = 0x100     # /**< image scanner vertical scan density */
+    CFG_Y_DENSITY = 0x101     # /**< image scanner horizontal scan density */
 
 
 # Structs


### PR DESCRIPTION
When the ZBar decoder encounters binary data, it guesses the data encoding while converting it to text. This behavior destroys other types of data. 

Version 0.23.1 of the ZBar library supports decoding binary QR codes using configuration option `ZBAR_CFG_BINARY`. This PR allows settings this flag from the `decode()` function