### PR TITLE
Feature/117 windows ci external dlls

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,11 +6,11 @@ jobs:
   build:
     strategy:
       matrix:
-#        os: [ubuntu-18.04]
-#        python-version: [2.7, 3.6, 3.7, 3.8, 3.9, 3.10.0]
+        os: [ubuntu-18.04]
+        python-version: [2.7, 3.6, 3.7, 3.8, 3.9, 3.10.0]
         include:
-#          - os: macos-10.15
-#            python-version: 3.10.0
+          - os: macos-10.15
+            python-version: 3.10.0
           - os: windows-2019
             python-version: 3.10.0
             architecture: 'x86'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,14 +6,17 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-18.04]
-        python-version: [2.7, 3.6, 3.7, 3.8, 3.9, 3.10.0]
+#        os: [ubuntu-18.04]
+#        python-version: [2.7, 3.6, 3.7, 3.8, 3.9, 3.10.0]
         include:
-          - os: macos-10.15
+#          - os: macos-10.15
+#            python-version: 3.10.0
+          - os: windows-2019
             python-version: 3.10.0
-          # TODO Include DLLs in source code?
-          # - os: windows-2019
-          #   python-version: 3.10
+            architecture: 'x86'
+          - os: windows-2019
+            python-version: 3.10.0
+            architecture: 'x64'
 
     runs-on: ${{ matrix.os }}
 
@@ -30,6 +33,16 @@ jobs:
           brew update
           brew install zbar
 
+      - name: Download 32-bit DLLs
+        if: {{ runner.os == 'Windows' && matrix.architecture == 'x86' }}
+        run: |
+          wget https://github.com/NaturalHistoryMuseum/barcode-reader-dlls/releases/download/0.1/libzbar-32.dll https://github.com/NaturalHistoryMuseum/barcode-reader-dlls/releases/download/0.1/libiconv-2.dll
+
+      - name: Download 64-bit DLLs
+        if: {{ runner.os == 'Windows' && matrix.architecture == 'x64' }}
+        run: |
+          wget https://github.com/NaturalHistoryMuseum/barcode-reader-dlls/releases/download/0.1/libzbar-64.dll https://github.com/NaturalHistoryMuseum/barcode-reader-dlls/releases/download/0.1/libiconv.dll
+
       - name: Checkout
         uses: actions/checkout@v2
 
@@ -37,8 +50,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-          # TODO Both x64 and x86 on Windows
-          architecture: 'x64'
+          architecture: ${{ matrix.architecture }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,16 +33,6 @@ jobs:
           brew update
           brew install zbar
 
-      - name: Download 32-bit DLLs
-        if: {{ runner.os == 'Windows' && matrix.architecture == 'x86' }}
-        run: |
-          wget https://github.com/NaturalHistoryMuseum/barcode-reader-dlls/releases/download/0.1/libzbar-32.dll https://github.com/NaturalHistoryMuseum/barcode-reader-dlls/releases/download/0.1/libiconv-2.dll
-
-      - name: Download 64-bit DLLs
-        if: {{ runner.os == 'Windows' && matrix.architecture == 'x64' }}
-        run: |
-          wget https://github.com/NaturalHistoryMuseum/barcode-reader-dlls/releases/download/0.1/libzbar-64.dll https://github.com/NaturalHistoryMuseum/barcode-reader-dlls/releases/download/0.1/libiconv.dll
-
       - name: Checkout
         uses: actions/checkout@v2
 
@@ -56,6 +46,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip==20.3.4
           pip install -r requirements-test.txt
+
+      - name: Download 32-bit DLLs
+        if: {{ runner.os == 'Windows' && matrix.architecture == 'x86' }}
+        run: wget https://github.com/NaturalHistoryMuseum/barcode-reader-dlls/releases/download/0.1/libzbar-32.dll https://github.com/NaturalHistoryMuseum/barcode-reader-dlls/releases/download/0.1/libiconv-2.dll
+
+      - name: Download 64-bit DLLs
+        if: {{ runner.os == 'Windows' && matrix.architecture == 'x64' }}
+        run: wget https://github.com/NaturalHistoryMuseum/barcode-reader-dlls/releases/download/0.1/libzbar-64.dll https://github.com/NaturalHistoryMuseum/barcode-reader-dlls/releases/download/0.1/libiconv.dll
 
       - name: Run tests
         run: pytest --verbose --cov=pyzbar pyzbar

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,11 +49,17 @@ jobs:
 
       - name: Download 32-bit DLLs
         if: ${{ runner.os == 'Windows' && matrix.architecture == 'x86' }}
-        run: wget https://github.com/NaturalHistoryMuseum/barcode-reader-dlls/releases/download/0.1/libzbar-32.dll https://github.com/NaturalHistoryMuseum/barcode-reader-dlls/releases/download/0.1/libiconv-2.dll --directory-prefix pyzbar/
+        run: |
+          cd pyzbar
+          curl --location --remote-name-all "https://github.com/NaturalHistoryMuseum/barcode-reader-dlls/releases/download/0.1/{libzbar-32.dll,libiconv-2.dll}"
+          cd ..
 
       - name: Download 64-bit DLLs
         if: ${{ runner.os == 'Windows' && matrix.architecture == 'x64' }}
-        run: wget https://github.com/NaturalHistoryMuseum/barcode-reader-dlls/releases/download/0.1/libzbar-64.dll https://github.com/NaturalHistoryMuseum/barcode-reader-dlls/releases/download/0.1/libiconv.dll --directory-prefix pyzbar/
+        run: |
+          cd pyzbar
+          curl --location --remote-name-all "https://github.com/NaturalHistoryMuseum/barcode-reader-dlls/releases/download/0.1/{libzbar-64.dll,libiconv.dll}"
+          cd ..
 
       - name: Run tests
         run: pytest --verbose --cov=pyzbar pyzbar

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,12 +48,12 @@ jobs:
           pip install -r requirements-test.txt
 
       - name: Download 32-bit DLLs
-        if: {{ runner.os == 'Windows' && matrix.architecture == 'x86' }}
-        run: wget https://github.com/NaturalHistoryMuseum/barcode-reader-dlls/releases/download/0.1/libzbar-32.dll https://github.com/NaturalHistoryMuseum/barcode-reader-dlls/releases/download/0.1/libiconv-2.dll
+        if: ${{ runner.os == 'Windows' && matrix.architecture == 'x86' }}
+        run: wget https://github.com/NaturalHistoryMuseum/barcode-reader-dlls/releases/download/0.1/libzbar-32.dll https://github.com/NaturalHistoryMuseum/barcode-reader-dlls/releases/download/0.1/libiconv-2.dll --directory-prefix pyzbar/
 
       - name: Download 64-bit DLLs
-        if: {{ runner.os == 'Windows' && matrix.architecture == 'x64' }}
-        run: wget https://github.com/NaturalHistoryMuseum/barcode-reader-dlls/releases/download/0.1/libzbar-64.dll https://github.com/NaturalHistoryMuseum/barcode-reader-dlls/releases/download/0.1/libiconv.dll
+        if: ${{ runner.os == 'Windows' && matrix.architecture == 'x64' }}
+        run: wget https://github.com/NaturalHistoryMuseum/barcode-reader-dlls/releases/download/0.1/libzbar-64.dll https://github.com/NaturalHistoryMuseum/barcode-reader-dlls/releases/download/0.1/libiconv.dll --directory-prefix pyzbar/
 
       - name: Run tests
         run: pytest --verbose --cov=pyzbar pyzbar

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -20,10 +20,10 @@ rm -rf .tox && tox
 
 ### Windows
 
-Save the 32-bit and 64-bit `zbar.dll` files, and their dependencies,
-to `libzbar-32.dll` and `libzbar-64.dll` respectively, in the `pyzbar` directory.
-The `load_zbar` function in `wrapper.py` looks for the appropriate `DLL`s.
-The appropriate `DLL`s are packaged up into the wheel build and is installed
+The `pyzbar` directory contains both 32-bit (`libiconv-2.dll` and `libzbar-32.dll`)
+and 64-bit (`ibiconv.dll` and `libzbar-64.dll`) DLLs.
+The `load_zbar` function in `wrapper.py` looks for the appropriate DLLs.
+The appropriate DLLs are packaged up into the wheel build and are installed
 alongside the package source. This strategy allows the same method to be used
 when `pyzbar` is run from source, as an installed package and when included in a
 frozen binary.
@@ -31,23 +31,12 @@ frozen binary.
 ## Releasing
 
 1. Build
-    Create source and wheel builds. The `win32` and `win_amd64` wheels will
-    contain the appropriate `zbar.dll` and its dependencies.
+
+    Create wheel builds in the `dist` directory. The `win32` and `win_amd64`
+    wheels will contain the appropriate `zbar.dll` and its dependencies.
 
     ```
-    rm -rf build dist MANIFEST.in pyzbar.egg-info
-    cp MANIFEST.in.all MANIFEST.in
-    ./setup.py bdist_wheel
-
-    cat MANIFEST.in.all MANIFEST.in.win32 > MANIFEST.in
-    ./setup.py bdist_wheel --plat-name=win32
-
-    # Remove these dirs to prevent win32 DLLs from being included in win64 build
-    rm -rf build pyzbar.egg-info
-    cat MANIFEST.in.all MANIFEST.in.win64 > MANIFEST.in
-    ./setup.py bdist_wheel --plat-name=win_amd64
-
-    rm -rf build MANIFEST.in pyzbar.egg-info
+   ./build.sh
     ```
 
 2. Release to TestPyPI (see https://packaging.python.org/guides/using-testpypi/)

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -20,8 +20,8 @@ rm -rf .tox && tox
 
 ### Windows
 
-The `pyzbar` directory contains both 32-bit (`libiconv-2.dll` and `libzbar-32.dll`)
-and 64-bit (`ibiconv.dll` and `libzbar-64.dll`) DLLs.
+The `build.sh` script downloads both the 32-bit (`libiconv-2.dll` and `libzbar-32.dll`)
+and 64-bit (`ibiconv.dll` and `libzbar-64.dll`) DLLs to the `pyzbar` directory.
 The `load_zbar` function in `wrapper.py` looks for the appropriate DLLs.
 The appropriate DLLs are packaged up into the wheel build and are installed
 alongside the package source. This strategy allows the same method to be used

--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ provide support for Windows and depends upon Pillow.
 Installation
 ------------
 
-The ``zbar`` ``DLL``\ s are included with the Windows Python wheels.
+The ``zbar`` DLLs are included with the Windows Python wheels.
 On other operating systems, you will need to install the ``zbar`` shared
 library.
 
@@ -216,10 +216,11 @@ ZBar versions
 Development of the `original zbar <http://zbar.sourceforge.net/>`__ stopped in 2012.
 Development was started again in 2019 under a `new project <https://github.com/mchehab/zbar/>`__
 that has added some new features, including support for decoding
-barcode orientation. At the time of writing the project does not produce Windows DLLs.
-If you see `orientation=None` then your system has an older release of zbar.
-The ``zbar`` ``DLL``\ s that are included with the Windows Python wheels are
-an old build that does not support orientation.
+barcode orientation. At the time of writing this new project does not produce Windows DLLs.
+The ``zbar`` DLLs that are included with the Windows Python wheels are built from the original
+project and so do not include support for decoding barcode orientation.
+If you see ``orientation=None`` then your system has an older release of zbar that does
+not support orientation.
 
 Quality field
 -------------
@@ -264,5 +265,5 @@ License
 -------
 
 ``pyzbar`` is distributed under the MIT license (see ``LICENCE.txt``).
-The ``zbar`` shared library is distributed under the GNU Lesser General
-Public License, version 2.1 (see ``zbar-LICENCE.txt``).
+The ``zbar`` shared library is distributed under the
+[GNU Lesser General Public License, version 2.1](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html).

--- a/build.sh
+++ b/build.sh
@@ -3,10 +3,11 @@ rm -rf build dist MANIFEST.in pyzbar.egg-info
 cp MANIFEST.in.all MANIFEST.in
 ./setup.py bdist_wheel
 
-DLL_ROOT=https://github.com/NaturalHistoryMuseum/barcode-reader-dlls/releases/download/0.1
 if [ ! -f pyzbar/libzbar-32.dll ]; then
   echo Fetch DLLs
-  wget $DLL_ROOT/libzbar-32.dll $DLL_ROOT/libiconv-2.dll $DLL_ROOT/libzbar-64.dll $DLL_ROOT/libiconv.dll --directory-prefix pyzbar/
+  cd pyzbar
+  curl --location --remote-name-all "https://github.com/NaturalHistoryMuseum/barcode-reader-dlls/releases/download/0.1/{libzbar-32.dll,libiconv-2.dll,libzbar-64.dll,libiconv.dll}"
+  cd ..
 fi
 
 echo Windows 32-bit wheel

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,24 @@
+echo Source wheel
+rm -rf build dist MANIFEST.in pyzbar.egg-info
+cp MANIFEST.in.all MANIFEST.in
+./setup.py bdist_wheel
+
+DLL_ROOT=https://github.com/NaturalHistoryMuseum/barcode-reader-dlls/releases/download/0.1
+if [ ! -f pyzbar/libzbar-32.dll ]; then
+  echo Fetch DLLs
+  wget $DLL_ROOT/libzbar-32.dll $DLL_ROOT/libiconv-2.dll $DLL_ROOT/libzbar-64.dll $DLL_ROOT/libiconv.dll --directory-prefix pyzbar/
+fi
+
+echo Windows 32-bit wheel
+rm -rf build pyzbar.egg-info
+cat MANIFEST.in.all MANIFEST.in.win32 > MANIFEST.in
+./setup.py bdist_wheel --plat-name=win32
+
+echo Windows 32-bit wheel
+# Remove these dirs to prevent win32 DLLs from being included in win64 build
+rm -rf build pyzbar.egg-info
+cat MANIFEST.in.all MANIFEST.in.win64 > MANIFEST.in
+./setup.py bdist_wheel --plat-name=win_amd64
+
+echo Clean
+rm -rf build MANIFEST.in pyzbar.egg-info


### PR DESCRIPTION
Closes #117.

This PR add a CI step to download the appropriate Windows DLLs from the [barcode-reader-dlls](https://github.com/NaturalHistoryMuseum/barcode-reader-dlls) repo.