### PR TITLE
Update zbar_library.py

### DIFF
--- a/pyzbar/zbar_library.py
+++ b/pyzbar/zbar_library.py
@@ -55,7 +55,7 @@ def load():
             return deps, libzbar
 
         try:
-            dependencies, libzbar = load_objects(Path(''))
+            dependencies, libzbar = load_objects(Path('').absolute())
         except OSError:
             dependencies, libzbar = load_objects(Path(__file__).parent)
     else:


### PR DESCRIPTION
Fix a BUG that cannot load DLL at current dictionary on win10.