### PR TITLE
Conda Support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,13 @@ Mac OS X:
 ::
 
    brew install zbar
+   
+or
+
+::
+
+   conda install -c conda-forge zbar
+
 
 Linux:
 


### PR DESCRIPTION
Brew fails on M1 chip and makes zbar usage impossible. Conda install solves that problem. Just added.