### PR TITLE
fix return type of `zbar_symbol_get_orientation`

### DIFF
--- a/pyzbar/wrapper.py
+++ b/pyzbar/wrapper.py
@@ -274,7 +274,7 @@ zbar_symbol_get_loc_y = zbar_function(
 try:
     zbar_symbol_get_orientation = zbar_function(
         'zbar_symbol_get_orientation',
-        c_uint,
+        c_int,
         POINTER(zbar_symbol)
     )
 except AttributeError:


### PR DESCRIPTION
Fixes #139. Implements @simon-staal's [proposed solution](https://github.com/NaturalHistoryMuseum/pyzbar/issues/139#issuecomment-1597244185):

> The ZBarOrientation enum class specifies an `UNKNOWN` type as `-1` [here](https://github.com/NaturalHistoryMuseum/pyzbar/blob/ff2892666fa7cd305f0a95f9808159809c6fc222/pyzbar/wrapper.py#L88). However, when setting `zbar_symbol_get_orientation`, the `c_uint` type is passed [here](https://github.com/NaturalHistoryMuseum/pyzbar/blob/ff2892666fa7cd305f0a95f9808159809c6fc222/pyzbar/wrapper.py#L277). Presumably if this was changed to `c_int` this would solve this issue?

The [original zbar implementation](https://github.com/mchehab/zbar/blob/150df8e19ebf5b13ce25c1e3e0a56446b4389acd/include/zbar.h#L140-L150) defines `zbar_orientation_t` as enum with `ZBAR_ORIENT_UNKNOWN = -1`. Hence, the return type of [`zbar_symbol_get_orientation`](https://github.com/mchehab/zbar/blob/150df8e19ebf5b13ce25c1e3e0a56446b4389acd/zbar/symbol.c#L291) is signed.